### PR TITLE
Add date_time_key param to EMA & SMA indicators

### DIFF
--- a/lib/technical_analysis/helpers/validation.rb
+++ b/lib/technical_analysis/helpers/validation.rb
@@ -20,10 +20,10 @@ module TechnicalAnalysis
       return true if (options.keys - valid_options).empty?
       raise ValidationError.new "Invalid options provided. Valid options are #{valid_options.join(", ")}"
     end
-  
-    def self.validate_date_time_key(data)
-      unless data.all? { |row| row.keys.include? :date_time }
-        raise ValidationError.new "Dataset must include date_time field with timestamps"
+
+    def self.validate_date_time_key(data, date_time_key=:date_time)
+      unless data.all? { |row| row.keys.include? date_time_key }
+        raise ValidationError.new "Dataset must include '#{date_time_key}' field with timestamps"
       end
     end
 

--- a/lib/technical_analysis/indicators/ema.rb
+++ b/lib/technical_analysis/indicators/ema.rb
@@ -20,7 +20,7 @@ module TechnicalAnalysis
     #
     # @return [Array] An array of keys as symbols for valid options for this technical indicator
     def self.valid_options
-      %i(period price_key)
+      %i(period price_key date_time_key)
     end
 
     # Validates the provided options for this technical indicator
@@ -48,16 +48,18 @@ module TechnicalAnalysis
     # @param data [Array] Array of hashes with keys (:date_time, :value)
     # @param period [Integer] The given period to calculate the EMA
     # @param price_key [Symbol] The hash key for the price data. Default :value
+    # @param date_time_key [Symbol] The hash key for the date time data. Default :date_time
     #
     # @return [Array<EmaValue>] An array of EmaValue instances
-    def self.calculate(data, period: 30, price_key: :value)
+    def self.calculate(data, period: 30, price_key: :value, date_time_key: :date_time)
       period = period.to_i
       price_key = price_key.to_sym
+      date_time_key = date_time_key.to_sym
       Validation.validate_numeric_data(data, price_key)
       Validation.validate_length(data, min_data_size(period: period))
-      Validation.validate_date_time_key(data)
+      Validation.validate_date_time_key(data, date_time_key)
 
-      data = data.sort_by { |row| row[:date_time] }
+      data = data.sort_by { |row| row[date_time_key] }
 
       output = []
       period_values = []
@@ -69,7 +71,7 @@ module TechnicalAnalysis
           ema = StockCalculation.ema(v[price_key], period_values, period, previous_ema)
           previous_ema = ema
 
-          output << EmaValue.new(date_time: v[:date_time], ema: ema)
+          output << EmaValue.new(date_time: v[date_time_key], ema: ema)
           period_values.shift
         end
       end

--- a/lib/technical_analysis/indicators/sma.rb
+++ b/lib/technical_analysis/indicators/sma.rb
@@ -20,7 +20,7 @@ module TechnicalAnalysis
     #
     # @return [Array] An array of keys as symbols for valid options for this technical indicator
     def self.valid_options
-      %i(period price_key)
+      %i(period price_key date_time_key)
     end
 
     # Validates the provided options for this technical indicator
@@ -48,16 +48,18 @@ module TechnicalAnalysis
     # @param data [Array] Array of hashes with keys (:date_time, :value)
     # @param period [Integer] The given period to calculate the SMA
     # @param price_key [Symbol] The hash key for the price data. Default :value
+    # @param date_time_key [Symbol] The hash key for the date time data. Default :date_time
     #
     # @return [Array<SmaValue>] An array of SmaValue instances
-    def self.calculate(data, period: 30, price_key: :value)
+    def self.calculate(data, period: 30, price_key: :value, date_time_key: :date_time)
       period = period.to_i
       price_key = price_key.to_sym
+      date_time_key = date_time_key.to_sym
       Validation.validate_numeric_data(data, price_key)
       Validation.validate_length(data, min_data_size(period: period))
-      Validation.validate_date_time_key(data)
+      Validation.validate_date_time_key(data, date_time_key)
 
-      data = data.sort_by { |row| row[:date_time] }
+      data = data.sort_by { |row| row[date_time_key] }
 
       output = []
       period_values = []
@@ -65,7 +67,7 @@ module TechnicalAnalysis
       data.each do |v|
         period_values << v[price_key]
         if period_values.size == period
-          output << SmaValue.new(date_time: v[:date_time], sma: ArrayHelper.average(period_values))
+          output << SmaValue.new(date_time: v[date_time_key], sma: ArrayHelper.average(period_values))
           period_values.shift
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,12 +6,12 @@ class SpecHelper
   FLOAT_KEYS = [:open, :high, :low, :close].freeze
   INTEGER_KEYS = [:volume].freeze
 
-  def self.get_test_data(*columns)
+  def self.get_test_data(*columns, date_time_key: :date_time)
     @data = CSV.read(TEST_DATA_PATH, headers: true)
     columns = columns.map(&:to_sym)
     output = []
     @data.each do |v|
-      col_hash = { date_time: v["date_time"] }
+      col_hash = { date_time_key => v["date_time"] }
       columns.each do |col|
         value = v[col.to_s]
         value = value.to_f if FLOAT_KEYS.include?(col)

--- a/spec/technical_analysis/indicators/ema_spec.rb
+++ b/spec/technical_analysis/indicators/ema_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 
 describe 'Indicators' do
   describe "EMA" do
-    input_data = SpecHelper.get_test_data(:close)
+    input_data = SpecHelper.get_test_data(:close, date_time_key: :timestep)
     indicator = TechnicalAnalysis::Ema
 
     describe 'Exponential Moving Average' do
       it 'Calculates EMA (5 day)' do
-        output = indicator.calculate(input_data, period: 5, price_key: :close)
+        output = indicator.calculate(input_data, period: 5, price_key: :close, date_time_key: :timestep)
         normalized_output = output.map(&:to_hash)
 
         expected_output = [
@@ -92,11 +92,11 @@ describe 'Indicators' do
 
       it 'Returns the valid options' do
         valid_options = indicator.valid_options
-        expect(valid_options).to eq(%i(period price_key))
+        expect(valid_options).to eq(%i(period price_key date_time_key))
       end
 
       it 'Validates options' do
-        valid_options = { period: 22, price_key: :close }
+        valid_options = { period: 22, price_key: :close, date_time_key: :timestep }
         options_validated = indicator.validate_options(valid_options)
         expect(options_validated).to eq(true)
       end

--- a/spec/technical_analysis/indicators/indicator_spec.rb
+++ b/spec/technical_analysis/indicators/indicator_spec.rb
@@ -38,7 +38,7 @@ describe 'Indicators' do
 
       it 'Calculates valid_options' do
         valid_options = indicator.calculate('sma', [], :valid_options, { period: 20, price_key: :close })
-        expect(valid_options).to eq(%i(period price_key))
+        expect(valid_options).to eq(%i(period price_key date_time_key))
       end
 
       it 'Calculates validate_options' do

--- a/spec/technical_analysis/indicators/sma_spec.rb
+++ b/spec/technical_analysis/indicators/sma_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 
 describe 'Indicators' do
   describe "SMA" do
-    input_data = SpecHelper.get_test_data(:close)
+    input_data = SpecHelper.get_test_data(:close, date_time_key: :timestep)
     indicator = TechnicalAnalysis::Sma
 
     describe 'Simple Moving Average' do
       it 'Calculates SMA (5 day)' do
-        output = indicator.calculate(input_data, period: 5, price_key: :close)
+        output = indicator.calculate(input_data, period: 5, price_key: :close, date_time_key: :timestep)
         normalized_output = output.map(&:to_hash)
 
         expected_output = [
@@ -92,11 +92,11 @@ describe 'Indicators' do
 
       it 'Returns the valid options' do
         valid_options = indicator.valid_options
-        expect(valid_options).to eq(%i(period price_key))
+        expect(valid_options).to eq(%i(period price_key date_time_key))
       end
 
       it 'Validates options' do
-        valid_options = { period: 22, price_key: :close }
+        valid_options = { period: 22, price_key: :close, date_time_key: :timestep }
         options_validated = indicator.validate_options(valid_options)
         expect(options_validated).to eq(true)
       end


### PR DESCRIPTION
I've added the ability to customise the `date_time` key for EMA & SMA calculations in the same way it's possible to customise the `price` key. This is helpful to me so I don't have to remap my datasets.

I hope this is an acceptable change. 🙂