### PR TITLE
Handle division by zero error with mfi indicator

### DIFF
--- a/lib/technical_analysis/indicators/mfi.rb
+++ b/lib/technical_analysis/indicators/mfi.rb
@@ -80,7 +80,14 @@ module TechnicalAnalysis
           positive_period_flows = ArrayHelper.sum(raw_money_flows.map { |rmf| rmf.positive? ? rmf : 0 })
           negative_period_flows = ArrayHelper.sum(raw_money_flows.map { |rmf| rmf.negative? ? rmf.abs : 0 })
 
-          money_flow_ratio = (positive_period_flows / negative_period_flows)
+          if positive_period_flows == 0
+            money_flow_ratio = 0
+          elsif negative_period_flows == 0
+            money_flow_ratio = positive_period_flows
+          else
+            money_flow_ratio = (positive_period_flows / negative_period_flows)
+          end
+
           mfi = (100.00 - (100.00 / (1.0 + money_flow_ratio)))
 
           output << MfiValue.new(date_time: v[:date_time], mfi: mfi)


### PR DESCRIPTION
For the mfi indicator:

If no trading days for the period were negative, we'd end up with a divisor of zero, causing with a divide by zero error.  

The change here is to set the `money_flow_ratio` to `positive_period_flows` (a float) when there are no negative flows for the period

The ratio calculation for money flows over the period is `positive_period_flows / negative_period_flows`, with both flows representing the sum of the dollar value traded over the days in the period.     

While modifying the values, the `if` statement also checks if `positive_period_flows` is zero just to short circuit division (since it's unnecessary if the numerator is zero). 
